### PR TITLE
Remove wrapped render method of PostEffect

### DIFF
--- a/Engine/Node/PostEffect/PostEffectGaussianBlurNode.cs
+++ b/Engine/Node/PostEffect/PostEffectGaussianBlurNode.cs
@@ -57,10 +57,10 @@ namespace Altseed2
             var buffer = GetBuffer(0, src.Size);
 
             materialX.SetTexture("mainTex", src);
-            RenderToRenderTexture(materialX, buffer);
+            Engine.Graphics.CommandList.RenderToRenderTexture(materialX, buffer, new RenderPassParameter(Engine.ClearColor, true, true));
 
             materialY.SetTexture("mainTex", buffer);
-            RenderToRenderTarget(materialY);
+            Engine.Graphics.CommandList.RenderToRenderTarget(materialY);
         }
     }
 }

--- a/Engine/Node/PostEffect/PostEffectGrayScaleNode.cs
+++ b/Engine/Node/PostEffect/PostEffectGrayScaleNode.cs
@@ -16,7 +16,7 @@ namespace Altseed2
         protected override void Draw(RenderTexture src)
         {
             material.SetTexture("mainTex", src);
-            RenderToRenderTarget(material);
+            Engine.Graphics.CommandList.RenderToRenderTarget(material);
         }
     }
 }

--- a/Engine/Node/PostEffect/PostEffectLightBloomNode.cs
+++ b/Engine/Node/PostEffect/PostEffectLightBloomNode.cs
@@ -121,7 +121,10 @@ namespace Altseed2
                 _TextureMixer.SetTexture("mainTex2", downTexture[i]);
                 _TextureMixer.SetVector4F("weight", new Vector4F(weight, weight, weight, weight));
 
-                if (i == downSampleCount - 1) RenderToRenderTarget(_TextureMixer);
+                if (i == downSampleCount - 1)
+                {
+                    Engine.Graphics.CommandList.RenderToRenderTarget(_TextureMixer);
+                }
                 else
                 {
                     Engine.Graphics.CommandList.RenderToRenderTexture(_TextureMixer, outBuffer, renderParameter);

--- a/Engine/Node/PostEffect/PostEffectNode.cs
+++ b/Engine/Node/PostEffect/PostEffectNode.cs
@@ -78,16 +78,6 @@ namespace Altseed2
 
         protected abstract void Draw(RenderTexture src);
 
-        protected void RenderToRenderTarget(Material material)
-        {
-            Engine.Graphics.CommandList.RenderToRenderTarget(material);
-        }
-
-        protected void RenderToRenderTexture(Material material, RenderTexture texture)
-        {
-            Engine.Graphics.CommandList.RenderToRenderTexture(material, texture, new RenderPassParameter(new Color(50, 50, 50), true, true));// TODO: 適切な値を設定できるようにする
-        }
-
         #region Node
 
         internal override void Registered()

--- a/Engine/Node/PostEffect/PostEffectSepiaNode.cs
+++ b/Engine/Node/PostEffect/PostEffectSepiaNode.cs
@@ -16,7 +16,7 @@ namespace Altseed2
         protected override void Draw(RenderTexture src)
         {
             material.SetTexture("mainTex", src);
-            RenderToRenderTarget(material);
+            Engine.Graphics.CommandList.RenderToRenderTarget(material);
         }
     }
 }

--- a/Engine/Node/Transition/RuledTransitionNode.cs
+++ b/Engine/Node/Transition/RuledTransitionNode.cs
@@ -175,7 +175,7 @@ namespace Altseed2
             }
 
             _Material.SetTexture("_MainTex", src);
-            RenderToRenderTarget(_Material);
+            Engine.Graphics.CommandList.RenderToRenderTarget(_Material);
         }
     }
 }

--- a/Samples/Graphics/PostEffect.cs
+++ b/Samples/Graphics/PostEffect.cs
@@ -53,7 +53,7 @@ float4 main(PS_INPUT input) : SV_TARGET
             _Material.SetTexture("mainTex", src);
 
             // マテリアルを適用します。
-            RenderToRenderTarget(_Material);
+            Engine.Graphics.CommandList.RenderToRenderTarget(_Material);
         }
     }
 

--- a/Samples/Transition/Transition.cs
+++ b/Samples/Transition/Transition.cs
@@ -129,7 +129,7 @@ namespace Sample
             Material.SetTexture("mainTex", src);
 
             // ポストエフェクトを適用します。
-            RenderToRenderTarget(Material);
+            Engine.Graphics.CommandList.RenderToRenderTarget(Material);
         }
     }
 }

--- a/Test/PostEffectNode.cs
+++ b/Test/PostEffectNode.cs
@@ -56,7 +56,7 @@ float4 tex = mainTex.Sample(mainSamp, float2(x, input.UV1.y));
                 count = (count + 1) % 200;
                 material.SetVector4F("time", new Vector4F(count / 200.0f, 0.0f, 0.0f, 0.0f));
 
-                RenderToRenderTarget(material);
+                Engine.Graphics.CommandList.RenderToRenderTarget(material);
             }
         }
 


### PR DESCRIPTION
CommandListのメソッドを直接呼び出すようにした。
実装当初はCommandListがinternalになっていたため。

https://github.com/altseed/Altseed2/issues/440