### PR TITLE
fix initial PolygonNodes/ShapeNodes.Vertexes causes core error

### DIFF
--- a/Engine/Node/PolygonNode.cs
+++ b/Engine/Node/PolygonNode.cs
@@ -11,7 +11,7 @@ namespace Altseed2
     {
         protected private readonly RenderedPolygon _RenderedPolygon;
 
-        private bool _IsValid;
+        private bool _IsValid = false;
 
         /// <summary>
         /// <see cref="PolygonNode"/>の新しいインスタンスを生成します。
@@ -19,7 +19,6 @@ namespace Altseed2
         public PolygonNode()
         {
             _RenderedPolygon = RenderedPolygon.Create();
-            _RenderedPolygon.Vertexes = VertexArray.Create(0); //TODO: Core の更新で不要になる。
         }
 
         #region IDrawn
@@ -193,16 +192,10 @@ namespace Altseed2
             set
             {
                 var vertexArray = VertexArray.Create(value);
-                _IsValid = CheckIsValid(vertexArray);
-                if (_IsValid)
-                {
-                    _RenderedPolygon.Vertexes = vertexArray;
-                    _RequireCalcTransform = true;
-                }
-                else
-                {
-                    Engine.Log.Warn(LogCategory.Engine, "無効な頂点が登録されました。");
-                }
+                _RenderedPolygon.Vertexes = vertexArray;
+
+                _IsValid = Validate(vertexArray);
+                _RequireCalcTransform = true;
             }
         }
 
@@ -210,34 +203,44 @@ namespace Altseed2
         /// 頂点情報が有効かどうかを判定します。
         /// </summary>
         /// <param name="vertexes">頂点情報</param>
-        private bool CheckIsValid(VertexArray vertexes)
+        private bool Validate(VertexArray vertexes)
         {
-            if (vertexes.Count < 3) return false;
-            else
+            if (vertexes.Count < 3)
             {
-                for (int i = 0; i < vertexes.Count; ++i)
-                    for (int j = i + 1; j < vertexes.Count; ++j)
-                        if (vertexes[i].Position == vertexes[j].Position) return false;
-
-                return true;
+                Engine.Log.Info(LogCategory.Engine, $"{GetType()} に設定された頂点が 3 個未満のためこのノードは描画されません。");
+                return false;
             }
+
+            //for (int i = 0; i < vertexes.Count; ++i)
+            //    for (int j = i + 1; j < vertexes.Count; ++j)
+            //        if (vertexes[i].Position == vertexes[j].Position)
+            //        {
+            //            Engine.Log.Info(LogCategory.Engine, $"{GetType()} に設定された頂点に重複があるためこのノードは描画されません。");
+            //            return false;
+            //        }
+            return true;
         }
 
         /// <summary>
         /// 頂点情報が有効かどうかを判定します。
         /// </summary>
-        /// <param name="vertexes"><see cref="Vector2F"/>で表された頂点情報</param>
-        private bool CheckIsValid(Vector2FArray vertexes)
+        /// <param name="vertexes">頂点情報</param>
+        private bool Validate(Vector2FArray vertexes)
         {
-            if (vertexes.Count < 3) return false;
-            else
+            if (vertexes.Count < 3)
             {
-                for (int i = 0; i < vertexes.Count; ++i)
-                    for (int j = i + 1; j < vertexes.Count; ++j)
-                        if (vertexes[i] == vertexes[j]) return false;
-
-                return true;
+                Engine.Log.Info(LogCategory.Engine, $"{GetType()} に設定された頂点が 3 個未満のためこのノードは描画されません。");
+                return false;
             }
+
+            //for (int i = 0; i < vertexes.Count; ++i)
+            //    for (int j = i + 1; j < vertexes.Count; ++j)
+            //        if (vertexes[i] == vertexes[j])
+            //        {
+            //            Engine.Log.Info(LogCategory.Engine, $"{GetType()} に設定された頂点に重複があるためこのノードは描画されません。");
+            //            return false;
+            //        }
+            return true;
         }
 
         /// <summary>
@@ -259,19 +262,13 @@ namespace Altseed2
         /// </remarks>
         public void SetVertexes(IEnumerable<Vertex> vertexes)
         {
-            if (vertexes == null) throw new ArgumentNullException(nameof(vertexes), "引数がnullです");
+            if (vertexes == null) throw new ArgumentNullException(nameof(vertexes));
 
             var array = VertexArray.Create(vertexes);
-            _IsValid = CheckIsValid(array);
-            if (_IsValid)
-            {
-                _RenderedPolygon.Vertexes = array;
-                _RequireCalcTransform = true;
-            }
-            else
-            {
-                Engine.Log.Warn(LogCategory.Engine, "無効な頂点が登録されました。");
-            }
+            _RenderedPolygon.Vertexes = array;
+
+            _IsValid = Validate(array);
+            _RequireCalcTransform = true;
         }
 
         /// <summary>
@@ -285,17 +282,11 @@ namespace Altseed2
             if (vertexes == null) throw new ArgumentNullException(nameof(vertexes), "引数がnullです");
 
             var array = Vector2FArray.Create(vertexes);
-            _IsValid = CheckIsValid(array);
-            if (_IsValid)
-            {
-                _RenderedPolygon.CreateVertexesByVector2F(array);
-                _RenderedPolygon.OverwriteVertexesColor(color);
-                _RequireCalcTransform = true;
-            }
-            else
-            {
-                Engine.Log.Warn(LogCategory.Engine, "無効な頂点が登録されました。");
-            }
+            _RenderedPolygon.CreateVertexesByVector2F(array);
+            _RenderedPolygon.OverwriteVertexesColor(color);
+
+            _IsValid = Validate(array);
+            _RequireCalcTransform = true;
         }
 
         /// <inheritdoc/>

--- a/Engine/Node/ShapeNodes/ArcNode.cs
+++ b/Engine/Node/ShapeNodes/ArcNode.cs
@@ -50,7 +50,6 @@ namespace Altseed2
             get => _radius;
             set
             {
-                if (value <= 0.0f) throw new ArgumentException(nameof(value), $"設定しようとした値が小さすぎます。");
                 if (_radius == value) return;
 
                 _radius = value;

--- a/Engine/Node/ShapeNodes/ArcNode.cs
+++ b/Engine/Node/ShapeNodes/ArcNode.cs
@@ -44,7 +44,6 @@ namespace Altseed2
         /// <summary>
         /// 半径を取得または設定します。
         /// </summary>
-        /// <exception cref="ArgumentException">設定しようとした値が 0 以下</exception>
         public float Radius
         {
             get => _radius;

--- a/Engine/Node/ShapeNodes/ArcNode.cs
+++ b/Engine/Node/ShapeNodes/ArcNode.cs
@@ -8,7 +8,7 @@ namespace Altseed2
     [Serializable]
     public class ArcNode : ShapeNode
     {
-        private bool _RequireUpdateVertexes = false;
+        private bool _RequireUpdateVertexes = true;
 
         /// <summary>
         /// 色を取得または設定します。
@@ -44,18 +44,20 @@ namespace Altseed2
         /// <summary>
         /// 半径を取得または設定します。
         /// </summary>
+        /// <exception cref="ArgumentException">設定しようとした値が 0 以下</exception>
         public float Radius
         {
             get => _radius;
             set
             {
+                if (value <= 0.0f) throw new ArgumentException(nameof(value), $"設定しようとした値が小さすぎます。");
                 if (_radius == value) return;
 
                 _radius = value;
                 _RequireUpdateVertexes = true;
             }
         }
-        private float _radius;
+        private float _radius = 1.0f;
 
         /// <summary>
         /// 描画を開始する頂点を取得または設定します。

--- a/Engine/Node/ShapeNodes/CircleNode.cs
+++ b/Engine/Node/ShapeNodes/CircleNode.cs
@@ -29,7 +29,6 @@ namespace Altseed2
         /// <summary>
         /// 半径を取得または設定します。
         /// </summary>
-        /// <exception cref="ArgumentException">設定しようとした値が 0 以下</exception>
         public float Radius
         {
             get => _Radius;
@@ -46,6 +45,7 @@ namespace Altseed2
         /// <summary>
         /// 頂点の個数を取得または設定します。
         /// </summary>
+        /// <exception cref="ArgumentException">設定しようとした値が 3 未満</exception>
         public int VertNum
         {
             get => _VertNum;

--- a/Engine/Node/ShapeNodes/CircleNode.cs
+++ b/Engine/Node/ShapeNodes/CircleNode.cs
@@ -35,7 +35,6 @@ namespace Altseed2
             get => _Radius;
             set
             {
-                if (value <= 0.0f) throw new ArgumentException(nameof(value), $"設定しようとした値が小さすぎます。");
                 if (_Radius == value) return;
 
                 _Radius = value;

--- a/Engine/Node/ShapeNodes/CircleNode.cs
+++ b/Engine/Node/ShapeNodes/CircleNode.cs
@@ -8,7 +8,7 @@ namespace Altseed2
     [Serializable]
     public class CircleNode : ShapeNode
     {
-        private bool _RequireUpdateVertexes = false;
+        private bool _RequireUpdateVertexes = true;
 
         /// <summary>
         /// 色を取得または設定します。
@@ -29,18 +29,20 @@ namespace Altseed2
         /// <summary>
         /// 半径を取得または設定します。
         /// </summary>
+        /// <exception cref="ArgumentException">設定しようとした値が 0 以下</exception>
         public float Radius
         {
             get => _Radius;
             set
             {
+                if (value <= 0.0f) throw new ArgumentException(nameof(value), $"設定しようとした値が小さすぎます。");
                 if (_Radius == value) return;
 
                 _Radius = value;
                 _RequireUpdateVertexes = true;
             }
         }
-        private float _Radius;
+        private float _Radius = 1.0f;
 
         /// <summary>
         /// 頂点の個数を取得または設定します。

--- a/Engine/Node/ShapeNodes/LineNode.cs
+++ b/Engine/Node/ShapeNodes/LineNode.cs
@@ -8,7 +8,7 @@ namespace Altseed2
     [Serializable]
     public class LineNode : ShapeNode
     {
-        private bool _RequireUpdateVertexes = false;
+        private bool _RequireUpdateVertexes = true;
 
         /// <summary>
         /// 色を取得または設定します。
@@ -61,18 +61,20 @@ namespace Altseed2
         /// <summary>
         /// 直線の太さを取得または設定します。
         /// </summary>
+        /// <exception cref="ArgumentException">設定しようとした値が 0 以下</exception>
         public float Thickness
         {
             get => _Thickness;
             set
             {
+                if (value <= 0.0f) throw new ArgumentException(nameof(value), $"設定しようとした値が小さすぎます。");
                 if (_Thickness == value) return;
 
                 _Thickness = value;
                 _RequireUpdateVertexes = true;
             }
         }
-        private float _Thickness;
+        private float _Thickness = 1.0f;
 
         /// <summary>
         /// <see cref="LineNode"/>の新しいインスタンスを生成します。

--- a/Engine/Node/ShapeNodes/LineNode.cs
+++ b/Engine/Node/ShapeNodes/LineNode.cs
@@ -61,7 +61,6 @@ namespace Altseed2
         /// <summary>
         /// 直線の太さを取得または設定します。
         /// </summary>
-        /// <exception cref="ArgumentException">設定しようとした値が 0 以下</exception>
         public float Thickness
         {
             get => _Thickness;

--- a/Engine/Node/ShapeNodes/LineNode.cs
+++ b/Engine/Node/ShapeNodes/LineNode.cs
@@ -67,7 +67,6 @@ namespace Altseed2
             get => _Thickness;
             set
             {
-                if (value <= 0.0f) throw new ArgumentException(nameof(value), $"設定しようとした値が小さすぎます。");
                 if (_Thickness == value) return;
 
                 _Thickness = value;

--- a/Engine/Node/ShapeNodes/RectangleNode.cs
+++ b/Engine/Node/ShapeNodes/RectangleNode.cs
@@ -29,7 +29,6 @@ namespace Altseed2
         /// <summary>
         /// 短形のサイズを取得または設定します。
         /// </summary>
-        /// <exception cref="ArgumentException">設定しようとした値が 0 以下</exception>
         public Vector2F RectangleSize
         {
             get => _RectangleSize;

--- a/Engine/Node/ShapeNodes/RectangleNode.cs
+++ b/Engine/Node/ShapeNodes/RectangleNode.cs
@@ -35,15 +35,13 @@ namespace Altseed2
             get => _RectangleSize;
             set
             {
-                if (value.X <= 0.0f || value.Y <= 0.0f)
-                    throw new ArgumentException(nameof(value), $"設定しようとした値が小さすぎます。");
                 if (_RectangleSize == value) return;
 
                 _RectangleSize = value;
                 _RequireUpdateVertexes = true;
             }
         }
-        private Vector2F _RectangleSize = new Vector2F(1, 1);
+        private Vector2F _RectangleSize = new Vector2F();
 
         /// <summary>
         /// <see cref="RectangleNode"/>の新しいインスタンスを生成します。

--- a/Engine/Node/ShapeNodes/RectangleNode.cs
+++ b/Engine/Node/ShapeNodes/RectangleNode.cs
@@ -8,7 +8,7 @@ namespace Altseed2
     [Serializable]
     public class RectangleNode : ShapeNode
     {
-        private bool _RequireUpdateVertexes = false;
+        private bool _RequireUpdateVertexes = true;
 
         /// <summary>
         /// 色を取得または設定します。
@@ -29,18 +29,21 @@ namespace Altseed2
         /// <summary>
         /// 短形のサイズを取得または設定します。
         /// </summary>
+        /// <exception cref="ArgumentException">設定しようとした値が 0 以下</exception>
         public Vector2F RectangleSize
         {
             get => _RectangleSize;
             set
             {
+                if (value.X <= 0.0f || value.Y <= 0.0f)
+                    throw new ArgumentException(nameof(value), $"設定しようとした値が小さすぎます。");
                 if (_RectangleSize == value) return;
 
                 _RectangleSize = value;
                 _RequireUpdateVertexes = true;
             }
         }
-        private Vector2F _RectangleSize = new Vector2F();
+        private Vector2F _RectangleSize = new Vector2F(1, 1);
 
         /// <summary>
         /// <see cref="RectangleNode"/>の新しいインスタンスを生成します。

--- a/Engine/Node/ShapeNodes/ShapeNode.cs
+++ b/Engine/Node/ShapeNodes/ShapeNode.cs
@@ -17,7 +17,6 @@ namespace Altseed2
         protected ShapeNode()
         {
             _RenderedPolygon = RenderedPolygon.Create();
-            _RenderedPolygon.Vertexes = VertexArray.Create(0); //TODO: Core の更新で不要になる。
         }
 
         #region IDrawn
@@ -183,20 +182,6 @@ namespace Altseed2
         #endregion
 
         /// <summary>
-        /// 頂点情報のコレクションを取得します。
-        /// </summary>
-        public IReadOnlyList<Vertex> Vertexes
-        {
-            get => _RenderedPolygon.Vertexes?.ToArray();
-            private protected set
-            {
-                var vertexArray = VertexArray.Create(value);
-                _RenderedPolygon.Vertexes = vertexArray;
-                _RequireCalcTransform = true;
-            }
-        }
-
-        /// <summary>
         /// 各頂点に指定した色を設定する
         /// </summary>
         /// <param name="color">設定する色</param>
@@ -218,6 +203,7 @@ namespace Altseed2
             var array = Vector2FArray.Create(vertexes);
             _RenderedPolygon.CreateVertexesByVector2F(array);
             _RenderedPolygon.OverwriteVertexesColor(color);
+
             _RequireCalcTransform = true;
         }
 

--- a/Engine/Node/ShapeNodes/TriangleNode.cs
+++ b/Engine/Node/ShapeNodes/TriangleNode.cs
@@ -8,7 +8,7 @@ namespace Altseed2
     [Serializable]
     public class TriangleNode : ShapeNode
     {
-        private bool _RequireUpdateVertexes = false;
+        private bool _RequireUpdateVertexes = true;
         private Vector2F[] _Points;
 
         /// <summary>


### PR DESCRIPTION
PolygonNode/ShapeNodes.Vertexesは初期状態でサイズゼロなのでそのまま描画するとBatchRendererで落ちる。
以下のように修正

- PolygonNode：Vertexes.setter/SetVertexesで頂点数によるチェックを実施しその値（_IsValid）でDrawPolygonするか決める。
- ShapeNode：_RequireUpdateVertexesの初期値をtrueにする（初めてのUpdateで正常な頂点が生成される）
  - Line(4),Rectangle(4),Triangle(3)は頂点数が固定なので生成しさえすればおｋ
  - Circle,Arcは初期VertNum=3、VertNumに3未満を入れようとすると例外