### PR TITLE
fix CalcFromTransform

### DIFF
--- a/Engine/Math/MathHelper.cs
+++ b/Engine/Math/MathHelper.cs
@@ -191,10 +191,10 @@ namespace Altseed2
         public static void CalcFromTransform2D(Matrix44F transform, out Vector2F absolutePosition, out Vector2F scale, out float angle)
         {
             absolutePosition = new Vector2F(transform[0, 3], transform[1, 3]);
-            var sx = new Vector3F(transform[0, 0], transform[0, 1], transform[0, 2]).Length;
-            var sy = new Vector3F(transform[1, 0], transform[1, 1], transform[1, 2]).Length;
+            var sx = new Vector3F(transform[0, 0], transform[1, 0], transform[2, 0]).Length;
+            var sy = new Vector3F(transform[0, 1], transform[1, 1], transform[2, 1]).Length;
             scale = new Vector2F(sx, sy);
-            transform = Matrix44F.GetScale2D(new Vector2F(sx == 0 ? 1f : (1f / sx), sy == 0 ? 1f : (1f / sy))) * transform;
+            transform *= Matrix44F.GetScale2D(new Vector2F(sx == 0 ? 1f : (1f / sx), sy == 0 ? 1f : (1f / sy)));
             angle = new Vector2F(transform[0, 0], transform[1, 0]).Degree;
         }
 
@@ -208,12 +208,12 @@ namespace Altseed2
         public static void CalcFromTransform3D(Matrix44F transform, out Vector3F absolutePosition, out Vector3F scale, out Matrix44F rotation)
         {
             absolutePosition = new Vector3F(transform[0, 3], transform[1, 3], transform[2, 3]);
-            var sx = new Vector3F(transform[0, 0], transform[0, 1], transform[0, 2]).Length;
-            var sy = new Vector3F(transform[1, 0], transform[1, 1], transform[1, 2]).Length;
-            var sz = new Vector3F(transform[2, 0], transform[2, 1], transform[2, 2]).Length;
+            var sx = new Vector3F(transform[0, 0], transform[1, 0], transform[2, 0]).Length;
+            var sy = new Vector3F(transform[0, 1], transform[1, 1], transform[2, 1]).Length;
+            var sz = new Vector3F(transform[0, 2], transform[1, 2], transform[2, 2]).Length;
             scale = new Vector3F(sx, sy, sz);
             transform = Matrix44F.GetTranslation3D(-absolutePosition) * transform;
-            rotation = Matrix44F.GetScale3D(new Vector3F(sx == 0 ? 1f : (1f / sx), sy == 0 ? 1f : (1f / sy), sz == 0 ? 1f : (1f / sz))) * transform;
+            rotation = transform * Matrix44F.GetScale3D(new Vector3F(sx == 0 ? 1f : (1f / sx), sy == 0 ? 1f : (1f / sy), sz == 0 ? 1f : (1f / sz)));
         }
     }
 }

--- a/Test/Math.cs
+++ b/Test/Math.cs
@@ -42,7 +42,7 @@ namespace Altseed2.Test
             {
                 var radian = MathHelper.DegreeToRadian(angle);
                 var rotation = Matrix44F.GetRotationX(radian) * Matrix44F.GetRotationY(radian) * Matrix44F.GetRotationZ(radian);
-                var transform = Matrix44F.GetTranslation3D(position) * Matrix44F.GetScale3D(scale) * rotation;
+                var transform = Matrix44F.GetTranslation3D(position) * rotation * Matrix44F.GetScale3D(scale);
 
                 MathHelper.CalcFromTransform3D(transform, out var p, out var s, out var r);
                 TestValue(position, p);


### PR DESCRIPTION
## Changes/変更内容
Mathテストで死ぬ問題を修正

### 原因
いつぞやの修正でCalcTransformにおけるScale行列とRotation行列を掛ける順番が変わったことでAngleとScaleの逆算で死ぬように

## Issue
(該当無し)