### PR TITLE
Refine Children allocation

### DIFF
--- a/Engine/Collection/RegisterableCollection.cs
+++ b/Engine/Collection/RegisterableCollection.cs
@@ -11,7 +11,7 @@ namespace Altseed2
     internal class RegisterableCollection<T>
         where T : Registerable<T>
     {
-        private readonly List<T> CurrentCollection = new List<T>();
+        internal readonly List<T> CurrentCollection = new List<T>();
         private readonly Queue<T> AddQueue = new Queue<T>();
         private readonly Queue<T> RemoveQueue = new Queue<T>();
 

--- a/Engine/Collection/RegisterableCollection.cs
+++ b/Engine/Collection/RegisterableCollection.cs
@@ -134,9 +134,9 @@ namespace Altseed2
         /// <summary>
         /// 現在の要素の読み取り専用なコレクションを返します。
         /// </summary>
-        internal ReadOnlyCollection<T> AsReadOnly()
+        internal IReadOnlyList<T> AsReadOnly()
         {
-            return new ReadOnlyCollection<T>(CurrentCollection);
+            return CurrentCollection;
         }
 
         /// <summary>

--- a/Engine/Node/IDrawn.cs
+++ b/Engine/Node/IDrawn.cs
@@ -32,7 +32,7 @@ namespace Altseed2
         {
             node.IsDrawnActually = node.IsDrawn && (node.GetAncestorSpecificNode<T>()?.IsDrawnActually ?? true);
 
-            foreach (var child in node.Children)
+            foreach (var child in node._Children.CurrentCollection)
             {
                 if (child is T d)
                     d.UpdateIsDrawnActuallyOfDescendants();

--- a/Engine/Node/Node.cs
+++ b/Engine/Node/Node.cs
@@ -143,9 +143,9 @@ namespace Altseed2
         /// <summary>
         /// 子要素のコレクションを取得します。
         /// </summary>
-        public ReadOnlyCollection<Node> Children => _readonlyChildren ??= _Children.AsReadOnly();
+        public IReadOnlyList<Node> Children => _readonlyChildren ??= _Children.AsReadOnly();
         [NonSerialized]
-        private ReadOnlyCollection<Node> _readonlyChildren;
+        private IReadOnlyList<Node> _readonlyChildren;
 
         /// <summary>
         /// 子要素を追加します。

--- a/Engine/Node/Node.cs
+++ b/Engine/Node/Node.cs
@@ -29,7 +29,7 @@ namespace Altseed2
             _IsEnumeratingChildren = true;
 
             _Children.Update();
-            foreach (var c in Children)
+            foreach (var c in _Children.CurrentCollection)
             {
                 c.Update();
             }
@@ -101,7 +101,7 @@ namespace Altseed2
 
             _IsEnumeratingChildren = true;
 
-            foreach (var c in Children)
+            foreach (var c in _Children.CurrentCollection)
             {
                 if (!c._IsRegistered)
                 {
@@ -122,7 +122,7 @@ namespace Altseed2
         {
             _IsEnumeratingChildren = true;
 
-            foreach (var c in Children)
+            foreach (var c in _Children.CurrentCollection)
             {
                 c.Unregistered();
             }
@@ -332,7 +332,7 @@ namespace Altseed2
         {
             _IsEnumeratingChildren = true;
 
-            foreach (var c in Children)
+            foreach (var c in _Children.CurrentCollection)
             {
                 yield return c;
                 foreach (var g in c.EnumerateDescendants())
@@ -352,7 +352,7 @@ namespace Altseed2
         {
             _IsEnumeratingChildren = true;
 
-            foreach (var child in Children)
+            foreach (var child in _Children.CurrentCollection)
             {
                 foreach (var g in child.EnumerateDescendants(condition))
                     yield return g;

--- a/Engine/Node/Physics/ColliderNode.cs
+++ b/Engine/Node/Physics/ColliderNode.cs
@@ -26,7 +26,7 @@ namespace Altseed2
         private static CollisionManagerNode SearchManagerFromChildren(Node node)
         {
             if (node == null) return null;
-            foreach (var current in node.Children)
+            foreach (var current in node._Children.CurrentCollection)
                 if (current is CollisionManagerNode m)
                     return m;
             return null;

--- a/Engine/Node/TransformNode.cs
+++ b/Engine/Node/TransformNode.cs
@@ -304,7 +304,7 @@ namespace Altseed2
 
         private void ApplySizeChanged()
         {
-            foreach (var child in Children)
+            foreach (var child in _Children.CurrentCollection)
             {
                 ApplySizeChanged(child);
             }
@@ -329,7 +329,7 @@ namespace Altseed2
             }
             else
             {
-                foreach (var child in node.Children)
+                foreach (var child in node._Children.CurrentCollection)
                 {
                     ApplySizeChanged(child);
                 }
@@ -428,7 +428,7 @@ namespace Altseed2
                 s.InheritedTransform = matrix;
             }
 
-            foreach (var child in node.Children)
+            foreach (var child in node._Children.CurrentCollection)
             {
                 PropagateTransform(child, matrix);
             }

--- a/Engine/Physics/CollisionManagerNode.cs
+++ b/Engine/Physics/CollisionManagerNode.cs
@@ -35,7 +35,7 @@ namespace Altseed2
 
         internal static IEnumerable<ColliderNode> EnumerateColliderNodes(Node node)
         {
-            foreach (var current in node.Children)
+            foreach (var current in node._Children.CurrentCollection)
                 if (current is ColliderNode n)
                     yield return n;
         }
@@ -52,7 +52,7 @@ namespace Altseed2
 
         internal override void Added(Node owner)
         {
-            foreach (var child in owner.Children)
+            foreach (var child in owner._Children.CurrentCollection)
             {
                 if (child != this && child is CollisionManagerNode) throw new InvalidOperationException("既に衝突判定マネージャが格納されており，追加する事が出来ません");
                 foreach (var node in EnumerateColliderNodes(child))
@@ -63,7 +63,7 @@ namespace Altseed2
 
         internal override void Removed()
         {
-            foreach (var child in Parent.Children)
+            foreach (var child in Parent._Children.CurrentCollection)
                 foreach (var node in EnumerateColliderNodes(child))
                     RemoveCollider(node);
             base.Removed();


### PR DESCRIPTION
## Changes/変更内容
<!-- PRの概要を記述してください。 -->
- `List`を`interface`に`boxing`して`foreach`を行うと余計なallocationが発生する（ListのGetEnumeratorではstructで最適化される）ので、直接参照
- `RegisterableCollection`の`AsReadOnly`が`new ReadOnlyCollection<T>(CurrentCollection)`となっていたのを`CurrentCollection`を`IReadOnlyList<T>`にupcastして公開することで不要なnewの削減

<!-- Graphics関連の場合はスクリーンショットなどを貼るとレビューが楽です。 -->


## Issue
<!-- 対応するissueのURLを貼ってください。 -->
