### PR TITLE
#589

### DIFF
--- a/Engine/AutoGeneratedCoreBindings.cs
+++ b/Engine/AutoGeneratedCoreBindings.cs
@@ -2575,6 +2575,9 @@ namespace Altseed2
         }
         
         [EditorBrowsable(EditorBrowsableState.Never)]
+        bool ICacheKeeper<Int8Array>.SurpressReleasing => false;
+        
+        [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<Int8Array>.Release(IntPtr native) => cbg_Int8Array_Release(native);
         
         #endregion
@@ -2864,6 +2867,9 @@ namespace Altseed2
                 selfPtr = value;
             }
         }
+        
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool ICacheKeeper<Int32Array>.SurpressReleasing => false;
         
         [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<Int32Array>.Release(IntPtr native) => cbg_Int32Array_Release(native);
@@ -3157,6 +3163,9 @@ namespace Altseed2
         }
         
         [EditorBrowsable(EditorBrowsableState.Never)]
+        bool ICacheKeeper<VertexArray>.SurpressReleasing => false;
+        
+        [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<VertexArray>.Release(IntPtr native) => cbg_VertexArray_Release(native);
         
         #endregion
@@ -3448,6 +3457,9 @@ namespace Altseed2
         }
         
         [EditorBrowsable(EditorBrowsableState.Never)]
+        bool ICacheKeeper<FloatArray>.SurpressReleasing => false;
+        
+        [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<FloatArray>.Release(IntPtr native) => cbg_FloatArray_Release(native);
         
         #endregion
@@ -3737,6 +3749,9 @@ namespace Altseed2
                 selfPtr = value;
             }
         }
+        
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool ICacheKeeper<Vector2FArray>.SurpressReleasing => false;
         
         [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<Vector2FArray>.Release(IntPtr native) => cbg_Vector2FArray_Release(native);
@@ -5070,6 +5085,9 @@ namespace Altseed2
         }
         
         [EditorBrowsable(EditorBrowsableState.Never)]
+        bool ICacheKeeper<TextureBase>.SurpressReleasing => false;
+        
+        [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<TextureBase>.Release(IntPtr native) => cbg_TextureBase_Release(native);
         
         #endregion
@@ -5321,6 +5339,9 @@ namespace Altseed2
         }
         
         [EditorBrowsable(EditorBrowsableState.Never)]
+        bool ICacheKeeper<Texture2D>.SurpressReleasing => true;
+        
+        [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<Texture2D>.Release(IntPtr native) => cbg_Texture2D_Release(native);
         
         #endregion
@@ -5521,6 +5542,9 @@ namespace Altseed2
                 selfPtr = value;
             }
         }
+        
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool ICacheKeeper<RenderTexture>.SurpressReleasing => false;
         
         [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<RenderTexture>.Release(IntPtr native) => cbg_RenderTexture_Release(native);
@@ -5789,6 +5813,9 @@ namespace Altseed2
                 selfPtr = value;
             }
         }
+        
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool ICacheKeeper<Material>.SurpressReleasing => false;
         
         [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<Material>.Release(IntPtr native) => cbg_Material_Release(native);
@@ -6328,6 +6355,9 @@ namespace Altseed2
         }
         
         [EditorBrowsable(EditorBrowsableState.Never)]
+        bool ICacheKeeper<Rendered>.SurpressReleasing => false;
+        
+        [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<Rendered>.Release(IntPtr native) => cbg_Rendered_Release(native);
         
         #endregion
@@ -6671,6 +6701,9 @@ namespace Altseed2
                 selfPtr = value;
             }
         }
+        
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool ICacheKeeper<RenderedSprite>.SurpressReleasing => false;
         
         [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<RenderedSprite>.Release(IntPtr native) => cbg_RenderedSprite_Release(native);
@@ -7240,6 +7273,9 @@ namespace Altseed2
         }
         
         [EditorBrowsable(EditorBrowsableState.Never)]
+        bool ICacheKeeper<RenderedText>.SurpressReleasing => false;
+        
+        [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<RenderedText>.Release(IntPtr native) => cbg_RenderedText_Release(native);
         
         #endregion
@@ -7609,6 +7645,9 @@ namespace Altseed2
         }
         
         [EditorBrowsable(EditorBrowsableState.Never)]
+        bool ICacheKeeper<RenderedPolygon>.SurpressReleasing => false;
+        
+        [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<RenderedPolygon>.Release(IntPtr native) => cbg_RenderedPolygon_Release(native);
         
         #endregion
@@ -7885,6 +7924,9 @@ namespace Altseed2
                 selfPtr = value;
             }
         }
+        
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool ICacheKeeper<RenderedCamera>.SurpressReleasing => false;
         
         [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<RenderedCamera>.Release(IntPtr native) => cbg_RenderedCamera_Release(native);
@@ -8438,6 +8480,9 @@ namespace Altseed2
                 selfPtr = value;
             }
         }
+        
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool ICacheKeeper<Shader>.SurpressReleasing => false;
         
         [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<Shader>.Release(IntPtr native) => cbg_Shader_Release(native);
@@ -9041,6 +9086,9 @@ namespace Altseed2
                 selfPtr = value;
             }
         }
+        
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool ICacheKeeper<Font>.SurpressReleasing => true;
         
         [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<Font>.Release(IntPtr native) => cbg_Font_Release(native);
@@ -12777,6 +12825,9 @@ namespace Altseed2
         }
         
         [EditorBrowsable(EditorBrowsableState.Never)]
+        bool ICacheKeeper<StreamFile>.SurpressReleasing => true;
+        
+        [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<StreamFile>.Release(IntPtr native) => cbg_StreamFile_Release(native);
         
         #endregion
@@ -13074,6 +13125,9 @@ namespace Altseed2
                 selfPtr = value;
             }
         }
+        
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool ICacheKeeper<StaticFile>.SurpressReleasing => true;
         
         [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<StaticFile>.Release(IntPtr native) => cbg_StaticFile_Release(native);
@@ -13632,6 +13686,9 @@ namespace Altseed2
                 selfPtr = value;
             }
         }
+        
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool ICacheKeeper<Sound>.SurpressReleasing => true;
         
         [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<Sound>.Release(IntPtr native) => cbg_Sound_Release(native);
@@ -14498,6 +14555,9 @@ namespace Altseed2
         }
         
         [EditorBrowsable(EditorBrowsableState.Never)]
+        bool ICacheKeeper<Collider>.SurpressReleasing => false;
+        
+        [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<Collider>.Release(IntPtr native) => cbg_Collider_Release(native);
         
         #endregion
@@ -14703,6 +14763,9 @@ namespace Altseed2
                 selfPtr = value;
             }
         }
+        
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool ICacheKeeper<CircleCollider>.SurpressReleasing => false;
         
         [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<CircleCollider>.Release(IntPtr native) => cbg_CircleCollider_Release(native);
@@ -14946,6 +15009,9 @@ namespace Altseed2
         }
         
         [EditorBrowsable(EditorBrowsableState.Never)]
+        bool ICacheKeeper<RectangleCollider>.SurpressReleasing => false;
+        
+        [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<RectangleCollider>.Release(IntPtr native) => cbg_RectangleCollider_Release(native);
         
         #endregion
@@ -15125,6 +15191,9 @@ namespace Altseed2
                 selfPtr = value;
             }
         }
+        
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool ICacheKeeper<PolygonCollider>.SurpressReleasing => false;
         
         [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<PolygonCollider>.Release(IntPtr native) => cbg_PolygonCollider_Release(native);

--- a/Engine/AutoGeneratedCoreBindings.cs
+++ b/Engine/AutoGeneratedCoreBindings.cs
@@ -2491,7 +2491,7 @@ namespace Altseed2
             var ptr = Call_GetPtr(info);
             
             if (ptr == IntPtr.Zero) throw new SerializationException("インスタンス生成に失敗しました");
-            CacheHelper.CacheHandling(this, ptr);
+            CacheHelper.CacheHandlingOnDeserialization(this, ptr);
             
             
             OnDeserialize_Constructor(info, context);
@@ -2785,7 +2785,7 @@ namespace Altseed2
             var ptr = Call_GetPtr(info);
             
             if (ptr == IntPtr.Zero) throw new SerializationException("インスタンス生成に失敗しました");
-            CacheHelper.CacheHandling(this, ptr);
+            CacheHelper.CacheHandlingOnDeserialization(this, ptr);
             
             
             OnDeserialize_Constructor(info, context);
@@ -3079,7 +3079,7 @@ namespace Altseed2
             var ptr = Call_GetPtr(info);
             
             if (ptr == IntPtr.Zero) throw new SerializationException("インスタンス生成に失敗しました");
-            CacheHelper.CacheHandling(this, ptr);
+            CacheHelper.CacheHandlingOnDeserialization(this, ptr);
             
             
             OnDeserialize_Constructor(info, context);
@@ -3373,7 +3373,7 @@ namespace Altseed2
             var ptr = Call_GetPtr(info);
             
             if (ptr == IntPtr.Zero) throw new SerializationException("インスタンス生成に失敗しました");
-            CacheHelper.CacheHandling(this, ptr);
+            CacheHelper.CacheHandlingOnDeserialization(this, ptr);
             
             
             OnDeserialize_Constructor(info, context);
@@ -3667,7 +3667,7 @@ namespace Altseed2
             var ptr = Call_GetPtr(info);
             
             if (ptr == IntPtr.Zero) throw new SerializationException("インスタンス生成に失敗しました");
-            CacheHelper.CacheHandling(this, ptr);
+            CacheHelper.CacheHandlingOnDeserialization(this, ptr);
             
             
             OnDeserialize_Constructor(info, context);
@@ -5106,7 +5106,7 @@ namespace Altseed2
             var ptr = Call_GetPtr(seInfo);
             
             if (ptr == IntPtr.Zero) throw new SerializationException("インスタンス生成に失敗しました");
-            CacheHelper.CacheHandlingConcurrent(this, ptr);
+            CacheHelper.CacheHandlingOnDeserializationConcurrent(this, ptr);
             
             WrapMode = seInfo.GetValue<TextureWrapMode>(S_WrapMode);
             FilterType = seInfo.GetValue<TextureFilter>(S_FilterType);
@@ -5361,7 +5361,7 @@ namespace Altseed2
             if (ptr == IntPtr.Zero) ptr = Call_GetPtr(seInfo);
             
             if (ptr == IntPtr.Zero) throw new SerializationException("インスタンス生成に失敗しました");
-            CacheHelper.CacheHandlingConcurrent(this, ptr);
+            CacheHelper.CacheHandlingOnDeserializationConcurrent(this, ptr);
             
             base.OnDeserialization(sender);
             
@@ -5566,7 +5566,7 @@ namespace Altseed2
             if (ptr == IntPtr.Zero) ptr = Call_GetPtr(seInfo);
             
             if (ptr == IntPtr.Zero) throw new SerializationException("インスタンス生成に失敗しました");
-            CacheHelper.CacheHandling(this, ptr);
+            CacheHelper.CacheHandlingOnDeserialization(this, ptr);
             
             base.OnDeserialization(sender);
             
@@ -5741,7 +5741,7 @@ namespace Altseed2
             var ptr = Call_GetPtr(info);
             
             if (ptr == IntPtr.Zero) throw new SerializationException("インスタンス生成に失敗しました");
-            CacheHelper.CacheHandling(this, ptr);
+            CacheHelper.CacheHandlingOnDeserialization(this, ptr);
             
             AlphaBlend = info.GetValue<AlphaBlend>(S_AlphaBlend);
             
@@ -6279,7 +6279,7 @@ namespace Altseed2
             var ptr = Call_GetPtr(info);
             
             if (ptr == IntPtr.Zero) throw new SerializationException("インスタンス生成に失敗しました");
-            CacheHelper.CacheHandling(this, ptr);
+            CacheHelper.CacheHandlingOnDeserialization(this, ptr);
             
             Transform = info.GetValue<Matrix44F>(S_Transform);
             
@@ -6619,7 +6619,7 @@ namespace Altseed2
             if (ptr == IntPtr.Zero) ptr = Call_GetPtr(info);
             
             if (ptr == IntPtr.Zero) throw new SerializationException("インスタンス生成に失敗しました");
-            CacheHelper.CacheHandling(this, ptr);
+            CacheHelper.CacheHandlingOnDeserialization(this, ptr);
             
             var Texture = info.GetValue<TextureBase>(S_Texture);
             ((IDeserializationCallback)Texture)?.OnDeserialization(null);
@@ -7177,7 +7177,7 @@ namespace Altseed2
             if (ptr == IntPtr.Zero) ptr = Call_GetPtr(info);
             
             if (ptr == IntPtr.Zero) throw new SerializationException("インスタンス生成に失敗しました");
-            CacheHelper.CacheHandling(this, ptr);
+            CacheHelper.CacheHandlingOnDeserialization(this, ptr);
             
             MaterialGlyph = info.GetValue<Material>(S_MaterialGlyph);
             MaterialImage = info.GetValue<Material>(S_MaterialImage);
@@ -7561,7 +7561,7 @@ namespace Altseed2
             if (ptr == IntPtr.Zero) ptr = Call_GetPtr(info);
             
             if (ptr == IntPtr.Zero) throw new SerializationException("インスタンス生成に失敗しました");
-            CacheHelper.CacheHandling(this, ptr);
+            CacheHelper.CacheHandlingOnDeserialization(this, ptr);
             
             Vertexes = info.GetValue<VertexArray>(S_Vertexes);
             var Texture = info.GetValue<TextureBase>(S_Texture);
@@ -7846,7 +7846,7 @@ namespace Altseed2
             var ptr = Call_GetPtr(info);
             
             if (ptr == IntPtr.Zero) throw new SerializationException("インスタンス生成に失敗しました");
-            CacheHelper.CacheHandling(this, ptr);
+            CacheHelper.CacheHandlingOnDeserialization(this, ptr);
             
             ViewMatrix = info.GetValue<Matrix44F>(S_ViewMatrix);
             var TargetTexture = info.GetValue<RenderTexture>(S_TargetTexture);
@@ -8392,7 +8392,7 @@ namespace Altseed2
             var ptr = Call_GetPtr(info);
             
             if (ptr == IntPtr.Zero) throw new SerializationException("インスタンス生成に失敗しました");
-            CacheHelper.CacheHandling(this, ptr);
+            CacheHelper.CacheHandlingOnDeserialization(this, ptr);
             
             
             OnDeserialize_Constructor(info, context);
@@ -9109,7 +9109,7 @@ namespace Altseed2
             var ptr = Call_GetPtr(seInfo);
             
             if (ptr == IntPtr.Zero) throw new SerializationException("インスタンス生成に失敗しました");
-            CacheHelper.CacheHandlingConcurrent(this, ptr);
+            CacheHelper.CacheHandlingOnDeserializationConcurrent(this, ptr);
             
             
             OnDeserialize_Method(sender);
@@ -12846,7 +12846,7 @@ namespace Altseed2
             var ptr = Call_GetPtr(seInfo);
             
             if (ptr == IntPtr.Zero) throw new SerializationException("インスタンス生成に失敗しました");
-            CacheHelper.CacheHandlingConcurrent(this, ptr);
+            CacheHelper.CacheHandlingOnDeserializationConcurrent(this, ptr);
             
             
             OnDeserialize_Method(sender);
@@ -13043,7 +13043,7 @@ namespace Altseed2
             var ptr = Call_GetPtr(info);
             
             if (ptr == IntPtr.Zero) throw new SerializationException("インスタンス生成に失敗しました");
-            CacheHelper.CacheHandlingConcurrent(this, ptr);
+            CacheHelper.CacheHandlingOnDeserializationConcurrent(this, ptr);
             
             
             OnDeserialize_Constructor(info, context);
@@ -13595,7 +13595,7 @@ namespace Altseed2
             var ptr = Call_GetPtr(info);
             
             if (ptr == IntPtr.Zero) throw new SerializationException("インスタンス生成に失敗しました");
-            CacheHelper.CacheHandlingConcurrent(this, ptr);
+            CacheHelper.CacheHandlingOnDeserializationConcurrent(this, ptr);
             
             LoopStartingPoint = info.GetSingle(S_LoopStartingPoint);
             LoopEndPoint = info.GetSingle(S_LoopEndPoint);
@@ -14479,7 +14479,7 @@ namespace Altseed2
             var ptr = Call_GetPtr(info);
             
             if (ptr == IntPtr.Zero) throw new SerializationException("インスタンス生成に失敗しました");
-            CacheHelper.CacheHandling(this, ptr);
+            CacheHelper.CacheHandlingOnDeserialization(this, ptr);
             
             Transform = info.GetValue<Matrix44F>(S_Transform);
             
@@ -14691,7 +14691,7 @@ namespace Altseed2
             if (ptr == IntPtr.Zero) ptr = Call_GetPtr(info);
             
             if (ptr == IntPtr.Zero) throw new SerializationException("インスタンス生成に失敗しました");
-            CacheHelper.CacheHandling(this, ptr);
+            CacheHelper.CacheHandlingOnDeserialization(this, ptr);
             
             Radius = info.GetSingle(S_Radius);
             
@@ -14933,7 +14933,7 @@ namespace Altseed2
             if (ptr == IntPtr.Zero) ptr = Call_GetPtr(info);
             
             if (ptr == IntPtr.Zero) throw new SerializationException("インスタンス生成に失敗しました");
-            CacheHelper.CacheHandling(this, ptr);
+            CacheHelper.CacheHandlingOnDeserialization(this, ptr);
             
             Size = info.GetValue<Vector2F>(S_Size);
             CenterPosition = info.GetValue<Vector2F>(S_CenterPosition);
@@ -15121,7 +15121,7 @@ namespace Altseed2
             if (ptr == IntPtr.Zero) ptr = Call_GetPtr(info);
             
             if (ptr == IntPtr.Zero) throw new SerializationException("インスタンス生成に失敗しました");
-            CacheHelper.CacheHandling(this, ptr);
+            CacheHelper.CacheHandlingOnDeserialization(this, ptr);
             
             
             OnDeserialize_Constructor(info, context);

--- a/Engine/AutoGeneratedCoreBindings.cs
+++ b/Engine/AutoGeneratedCoreBindings.cs
@@ -2575,9 +2575,6 @@ namespace Altseed2
         }
         
         [EditorBrowsable(EditorBrowsableState.Never)]
-        bool ICacheKeeper<Int8Array>.SurpressReleasing => false;
-        
-        [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<Int8Array>.Release(IntPtr native) => cbg_Int8Array_Release(native);
         
         #endregion
@@ -2867,9 +2864,6 @@ namespace Altseed2
                 selfPtr = value;
             }
         }
-        
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        bool ICacheKeeper<Int32Array>.SurpressReleasing => false;
         
         [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<Int32Array>.Release(IntPtr native) => cbg_Int32Array_Release(native);
@@ -3163,9 +3157,6 @@ namespace Altseed2
         }
         
         [EditorBrowsable(EditorBrowsableState.Never)]
-        bool ICacheKeeper<VertexArray>.SurpressReleasing => false;
-        
-        [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<VertexArray>.Release(IntPtr native) => cbg_VertexArray_Release(native);
         
         #endregion
@@ -3457,9 +3448,6 @@ namespace Altseed2
         }
         
         [EditorBrowsable(EditorBrowsableState.Never)]
-        bool ICacheKeeper<FloatArray>.SurpressReleasing => false;
-        
-        [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<FloatArray>.Release(IntPtr native) => cbg_FloatArray_Release(native);
         
         #endregion
@@ -3749,9 +3737,6 @@ namespace Altseed2
                 selfPtr = value;
             }
         }
-        
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        bool ICacheKeeper<Vector2FArray>.SurpressReleasing => false;
         
         [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<Vector2FArray>.Release(IntPtr native) => cbg_Vector2FArray_Release(native);
@@ -5085,9 +5070,6 @@ namespace Altseed2
         }
         
         [EditorBrowsable(EditorBrowsableState.Never)]
-        bool ICacheKeeper<TextureBase>.SurpressReleasing => false;
-        
-        [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<TextureBase>.Release(IntPtr native) => cbg_TextureBase_Release(native);
         
         #endregion
@@ -5339,9 +5321,6 @@ namespace Altseed2
         }
         
         [EditorBrowsable(EditorBrowsableState.Never)]
-        bool ICacheKeeper<Texture2D>.SurpressReleasing => true;
-        
-        [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<Texture2D>.Release(IntPtr native) => cbg_Texture2D_Release(native);
         
         #endregion
@@ -5542,9 +5521,6 @@ namespace Altseed2
                 selfPtr = value;
             }
         }
-        
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        bool ICacheKeeper<RenderTexture>.SurpressReleasing => false;
         
         [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<RenderTexture>.Release(IntPtr native) => cbg_RenderTexture_Release(native);
@@ -5813,9 +5789,6 @@ namespace Altseed2
                 selfPtr = value;
             }
         }
-        
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        bool ICacheKeeper<Material>.SurpressReleasing => false;
         
         [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<Material>.Release(IntPtr native) => cbg_Material_Release(native);
@@ -6355,9 +6328,6 @@ namespace Altseed2
         }
         
         [EditorBrowsable(EditorBrowsableState.Never)]
-        bool ICacheKeeper<Rendered>.SurpressReleasing => false;
-        
-        [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<Rendered>.Release(IntPtr native) => cbg_Rendered_Release(native);
         
         #endregion
@@ -6701,9 +6671,6 @@ namespace Altseed2
                 selfPtr = value;
             }
         }
-        
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        bool ICacheKeeper<RenderedSprite>.SurpressReleasing => false;
         
         [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<RenderedSprite>.Release(IntPtr native) => cbg_RenderedSprite_Release(native);
@@ -7273,9 +7240,6 @@ namespace Altseed2
         }
         
         [EditorBrowsable(EditorBrowsableState.Never)]
-        bool ICacheKeeper<RenderedText>.SurpressReleasing => false;
-        
-        [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<RenderedText>.Release(IntPtr native) => cbg_RenderedText_Release(native);
         
         #endregion
@@ -7645,9 +7609,6 @@ namespace Altseed2
         }
         
         [EditorBrowsable(EditorBrowsableState.Never)]
-        bool ICacheKeeper<RenderedPolygon>.SurpressReleasing => false;
-        
-        [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<RenderedPolygon>.Release(IntPtr native) => cbg_RenderedPolygon_Release(native);
         
         #endregion
@@ -7924,9 +7885,6 @@ namespace Altseed2
                 selfPtr = value;
             }
         }
-        
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        bool ICacheKeeper<RenderedCamera>.SurpressReleasing => false;
         
         [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<RenderedCamera>.Release(IntPtr native) => cbg_RenderedCamera_Release(native);
@@ -8480,9 +8438,6 @@ namespace Altseed2
                 selfPtr = value;
             }
         }
-        
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        bool ICacheKeeper<Shader>.SurpressReleasing => false;
         
         [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<Shader>.Release(IntPtr native) => cbg_Shader_Release(native);
@@ -9086,9 +9041,6 @@ namespace Altseed2
                 selfPtr = value;
             }
         }
-        
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        bool ICacheKeeper<Font>.SurpressReleasing => true;
         
         [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<Font>.Release(IntPtr native) => cbg_Font_Release(native);
@@ -12825,9 +12777,6 @@ namespace Altseed2
         }
         
         [EditorBrowsable(EditorBrowsableState.Never)]
-        bool ICacheKeeper<StreamFile>.SurpressReleasing => true;
-        
-        [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<StreamFile>.Release(IntPtr native) => cbg_StreamFile_Release(native);
         
         #endregion
@@ -13125,9 +13074,6 @@ namespace Altseed2
                 selfPtr = value;
             }
         }
-        
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        bool ICacheKeeper<StaticFile>.SurpressReleasing => true;
         
         [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<StaticFile>.Release(IntPtr native) => cbg_StaticFile_Release(native);
@@ -13686,9 +13632,6 @@ namespace Altseed2
                 selfPtr = value;
             }
         }
-        
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        bool ICacheKeeper<Sound>.SurpressReleasing => true;
         
         [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<Sound>.Release(IntPtr native) => cbg_Sound_Release(native);
@@ -14555,9 +14498,6 @@ namespace Altseed2
         }
         
         [EditorBrowsable(EditorBrowsableState.Never)]
-        bool ICacheKeeper<Collider>.SurpressReleasing => false;
-        
-        [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<Collider>.Release(IntPtr native) => cbg_Collider_Release(native);
         
         #endregion
@@ -14763,9 +14703,6 @@ namespace Altseed2
                 selfPtr = value;
             }
         }
-        
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        bool ICacheKeeper<CircleCollider>.SurpressReleasing => false;
         
         [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<CircleCollider>.Release(IntPtr native) => cbg_CircleCollider_Release(native);
@@ -15009,9 +14946,6 @@ namespace Altseed2
         }
         
         [EditorBrowsable(EditorBrowsableState.Never)]
-        bool ICacheKeeper<RectangleCollider>.SurpressReleasing => false;
-        
-        [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<RectangleCollider>.Release(IntPtr native) => cbg_RectangleCollider_Release(native);
         
         #endregion
@@ -15191,9 +15125,6 @@ namespace Altseed2
                 selfPtr = value;
             }
         }
-        
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        bool ICacheKeeper<PolygonCollider>.SurpressReleasing => false;
         
         [EditorBrowsable(EditorBrowsableState.Never)]
         void ICacheKeeper<PolygonCollider>.Release(IntPtr native) => cbg_PolygonCollider_Release(native);

--- a/Engine/InternalHelper/CacheHelper.cs
+++ b/Engine/InternalHelper/CacheHelper.cs
@@ -21,10 +21,6 @@ namespace Altseed2
         /// </summary>
         internal IntPtr Self { get; set; }
         /// <summary>
-        /// <see cref="Release(IntPtr)"/>を抑制するかどうかを取得します。
-        /// </summary>
-        internal bool SurpressReleasing { get; }
-        /// <summary>
         /// キャッシュを開放します。
         /// </summary>
         /// <param name="native">開放するオブジェクトのポインタ</param>
@@ -54,7 +50,6 @@ namespace Altseed2
                 obj.CacheRepo[native].TryGetTarget(out var cacheRet);
                 if (cacheRet != null)
                 {
-                    if (!obj.SurpressReleasing) obj.Release(native);
                     obj.Self = native;
                     return;
                 }
@@ -95,7 +90,6 @@ namespace Altseed2
                 cacheRepo[native].TryGetTarget(out var cacheRet);
                 if (cacheRet != null)
                 {
-                    if (!obj.SurpressReleasing) obj.Release(native);
                     obj.Self = native;
                     return;
                 }

--- a/Engine/InternalHelper/CacheHelper.cs
+++ b/Engine/InternalHelper/CacheHelper.cs
@@ -44,15 +44,15 @@ namespace Altseed2
         /// <param name="obj">キャッシュ制御を行うクラスのインスタンス</param>
         /// <param name="native"><paramref name="obj"/>に登録するポインタ</param>
         /// <exception cref="ArgumentNullException"><paramref name="obj"/>または<paramref name="native"/>がnull</exception>
-        internal static void CacheHandling<TClass>(TClass obj, IntPtr native) where TClass : class, ICacheKeeper<TClass>
+        internal static void CacheHandlingOnDeserialization<TClass>(TClass obj, IntPtr native) where TClass : class, ICacheKeeper<TClass>
         {
             if (obj == null) throw new ArgumentNullException(nameof(obj), "引数がnullです");
             if (native == IntPtr.Zero) throw new ArgumentNullException(nameof(native), "引数がnullです");
 
             if (obj.CacheRepo.ContainsKey(native))
             {
-                obj.CacheRepo[native].TryGetTarget(out var cacheSet);
-                if (cacheSet != null)
+                obj.CacheRepo[native].TryGetTarget(out var cacheRet);
+                if (cacheRet != null)
                 {
                     if (!obj.SurpressReleasing) obj.Release(native);
                     obj.Self = native;
@@ -73,7 +73,7 @@ namespace Altseed2
         /// <param name="native"><paramref name="obj"/>に登録するポインタ</param>
         /// <exception cref="ArgumentException">スレッドセーフなキャッシュ保存ディクショナリを取得できなかった</exception>
         /// <exception cref="ArgumentNullException"><paramref name="obj"/>または<paramref name="native"/>がnull</exception>
-        internal static void CacheHandlingConcurrent<TClass>(TClass obj, IntPtr native) where TClass : class, ICacheKeeper<TClass>
+        internal static void CacheHandlingOnDeserializationConcurrent<TClass>(TClass obj, IntPtr native) where TClass : class, ICacheKeeper<TClass>
         {
             if (obj == null) throw new ArgumentNullException(nameof(obj), "引数がnullです");
             if (native == IntPtr.Zero) throw new ArgumentNullException(nameof(native), "引数がnullです");
@@ -92,8 +92,8 @@ namespace Altseed2
 
             if (cacheRepo.ContainsKey(native))
             {
-                cacheRepo[native].TryGetTarget(out var cacheSet);
-                if (cacheSet != null)
+                cacheRepo[native].TryGetTarget(out var cacheRet);
+                if (cacheRet != null)
                 {
                     if (!obj.SurpressReleasing) obj.Release(native);
                     obj.Self = native;

--- a/Engine/InternalHelper/CacheHelper.cs
+++ b/Engine/InternalHelper/CacheHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -20,6 +20,10 @@ namespace Altseed2
         /// 自身のポインタを取得または設定します。
         /// </summary>
         internal IntPtr Self { get; set; }
+        /// <summary>
+        /// <see cref="Release(IntPtr)"/>を抑制するかどうかを取得します。
+        /// </summary>
+        internal bool SurpressReleasing { get; }
         /// <summary>
         /// キャッシュを開放します。
         /// </summary>
@@ -50,6 +54,7 @@ namespace Altseed2
                 obj.CacheRepo[native].TryGetTarget(out var cacheSet);
                 if (cacheSet != null)
                 {
+                    if (!obj.SurpressReleasing) obj.Release(native);
                     obj.Self = native;
                     return;
                 }
@@ -90,6 +95,7 @@ namespace Altseed2
                 cacheRepo[native].TryGetTarget(out var cacheSet);
                 if (cacheSet != null)
                 {
+                    if (!obj.SurpressReleasing) obj.Release(native);
                     obj.Self = native;
                     return;
                 }

--- a/Engine/InternalHelper/CacheHelper.cs
+++ b/Engine/InternalHelper/CacheHelper.cs
@@ -40,6 +40,7 @@ namespace Altseed2
         /// <param name="obj">キャッシュ制御を行うクラスのインスタンス</param>
         /// <param name="native"><paramref name="obj"/>に登録するポインタ</param>
         /// <exception cref="ArgumentNullException"><paramref name="obj"/>または<paramref name="native"/>がnull</exception>
+        /// <remarks>デシリアライズ時に実行</remarks>
         internal static void CacheHandlingOnDeserialization<TClass>(TClass obj, IntPtr native) where TClass : class, ICacheKeeper<TClass>
         {
             if (obj == null) throw new ArgumentNullException(nameof(obj), "引数がnullです");
@@ -68,6 +69,7 @@ namespace Altseed2
         /// <param name="native"><paramref name="obj"/>に登録するポインタ</param>
         /// <exception cref="ArgumentException">スレッドセーフなキャッシュ保存ディクショナリを取得できなかった</exception>
         /// <exception cref="ArgumentNullException"><paramref name="obj"/>または<paramref name="native"/>がnull</exception>
+        /// <remarks>デシリアライズ時に実行</remarks>
         internal static void CacheHandlingOnDeserializationConcurrent<TClass>(TClass obj, IntPtr native) where TClass : class, ICacheKeeper<TClass>
         {
             if (obj == null) throw new ArgumentNullException(nameof(obj), "引数がnullです");

--- a/Engine/InternalHelper/CacheHelper.cs
+++ b/Engine/InternalHelper/CacheHelper.cs
@@ -50,7 +50,6 @@ namespace Altseed2
                 obj.CacheRepo[native].TryGetTarget(out var cacheSet);
                 if (cacheSet != null)
                 {
-                    cacheSet.Release(native);
                     obj.Self = native;
                     return;
                 }
@@ -91,7 +90,6 @@ namespace Altseed2
                 cacheRepo[native].TryGetTarget(out var cacheSet);
                 if (cacheSet != null)
                 {
-                    cacheSet.Release(native);
                     obj.Self = native;
                     return;
                 }


### PR DESCRIPTION
## Changes/変更内容
デシリアライズ時にC#のインスタンス数 > C++のインスタンス数となりC#のデストラクタが全て走るとC++内の参照カウンタが負になって死ぬ問題を修正
デシリアライズ時に行われるキャッシュ操作のみを変更したので他の挙動は変化しない

## Issue
https://github.com/altseed/Altseed2/issues/589