### PR TITLE
fix posteffect src when using camera

### DIFF
--- a/Engine/Engine.cs
+++ b/Engine/Engine.cs
@@ -208,6 +208,8 @@ namespace Altseed2
 
             _PostEffectBuffer = null;
 
+            RenderTexture targetTexture = null;
+
             foreach (var (_, znodes) in drawns)
             {
                 foreach (var node in znodes)
@@ -220,9 +222,10 @@ namespace Altseed2
                             requireRender = false;
                         }
 
-                        _PostEffectBuffer ??= _RenderTextureCache.GetRenderTexture(Graphics.CommandList.GetScreenTexture().Size, Graphics.CommandList.ScreenTextureFormat);
+                        targetTexture ??= camera.TargetTexture ?? Graphics.CommandList.GetScreenTexture();
+                        _PostEffectBuffer ??= _RenderTextureCache.GetRenderTexture(targetTexture.Size, targetTexture.Format);
 
-                        Graphics.CommandList.CopyTexture(Graphics.CommandList.GetScreenTexture(), _PostEffectBuffer);
+                        Graphics.CommandList.CopyTexture(targetTexture, _PostEffectBuffer);
                         node.Draw();
                     }
                     else if (node is ICullableDrawn cdrawn)

--- a/Test/PostEffectNode.cs
+++ b/Test/PostEffectNode.cs
@@ -204,5 +204,47 @@ float4 tex = mainTex.Sample(mainSamp, float2(x, input.UV1.y));
 
             tc.End();
         }
+
+        [Test, Apartment(ApartmentState.STA)]
+        public void PostEffectWithCamera()
+        {
+            var tc = new TestCore();
+            tc.Init();
+
+            const ulong cameraGroup1 = 0b01;
+            const ulong cameraGroup2 = 0b10;
+
+            var texture = Texture2D.Load(@"TestData/IO/AltseedPink.png");
+            Assert.NotNull(texture);
+
+            Engine.AddNode(new SpriteNode()
+            {
+                Scale = new Vector2F(1.5f, 1.5f),
+                Texture = texture,
+                ZOrder = 1,
+                CameraGroup = cameraGroup1 | cameraGroup2,
+            });
+
+            Engine.AddNode(new PostEffectGaussianBlurNode()
+            {
+                ZOrder = 2,
+                CameraGroup = cameraGroup2,
+            });
+
+            var target = RenderTexture.Create((new Vector2F(0.5f, 1.0f) * Engine.Window.Size.To2F()).To2I(), TextureFormat.R8G8B8A8_UNORM);
+
+            Engine.AddNode(new CameraNode() { Group = cameraGroup2, TargetTexture = target, IsColorCleared = true, ClearColor = new Color(80, 80, 80) });
+
+            // 表示用
+            Engine.AddNode(new CameraNode() { Group = cameraGroup1 });
+            Engine.AddNode(new SpriteNode() { Texture = target, CameraGroup = cameraGroup1 });
+
+            tc.LoopBody(c =>
+            {
+
+            }, null);
+
+            tc.End();
+        }
     }
 }


### PR DESCRIPTION
## Changes/変更内容
<!-- PRの概要を記述してください。 -->
PostEffectをCameraに描画するときのsrc Textureがすべてスクリーンになっている。 
を修正。

<img width="912" alt="スクリーンショット 2020-09-09 22 59 49" src="https://user-images.githubusercontent.com/29581531/92608402-47450580-f2f0-11ea-8245-609b4f304e7e.png">


<!-- Graphics関連の場合はスクリーンショットなどを貼るとレビューが楽です。 -->


## Issue
<!-- 対応するissueのURLを貼ってください。 -->
https://github.com/altseed/Altseed2/issues/609
