### PR TITLE
Make Node Public : TransitionNode

### DIFF
--- a/Engine/Node/Transition/RuledTransitionNode.cs
+++ b/Engine/Node/Transition/RuledTransitionNode.cs
@@ -9,10 +9,6 @@ namespace Altseed2
     public sealed class RuledTransitionState
     {
         /// <summary>
-        /// この設定を適用するノードを取得または設定します。
-        /// </summary>
-        public Node TargetNode { get; set; }
-        /// <summary>
         /// 遷移に掛かる時間を取得または設定します。
         /// </summary>
         public float Duration { get; set; }
@@ -43,7 +39,6 @@ namespace Altseed2
         /// <param name="maskTexture">指定するマスクテクスチャ</param>
         /// 
         public RuledTransitionNode(RuledTransitionState closingState, RuledTransitionState openingState, Texture2D maskTexture = null)
-            : base(closingState.TargetNode, openingState.TargetNode, closingState.Duration, openingState.Duration)
         {
             if (!Engine.Config.EnabledCoreModules.HasFlag(CoreModules.Graphics))
             {
@@ -61,6 +56,9 @@ namespace Altseed2
                 MixRate = 0.0f,
                 UseCaptionAsMaskTexture = maskTexture != null,
             };
+
+            ClosingDuration = closingState.Duration;
+            OpeningDuration = openingState.Duration;
         }
 
         internal override void TransitionBegin()

--- a/Engine/Node/Transition/TransitionNode.cs
+++ b/Engine/Node/Transition/TransitionNode.cs
@@ -24,12 +24,30 @@ namespace Altseed2
         /// <summary>
         /// トランジションが始まってからノードが入れ替わるまでの期間
         /// </summary>
-        public float ClosingDuration { get; set; }
+        public float ClosingDuration
+        {
+            get => _ClosingDuration;
+            set
+            {
+                if (!_OnTransition) _ClosingDuration = value;
+                else Engine.Log.Error(LogCategory.Engine, "Cannot set value during transition.");
+            }
+        }
+        private float _ClosingDuration;
 
         /// <summary>
         /// ノードが入れ替わってからトランジションが終わるまでの期間
         /// </summary>
-        public float OpeningDuration { get; set; }
+        public float OpeningDuration
+        {
+            get => _OpeningDuration;
+            set
+            {
+                if (!_OnTransition) _OpeningDuration = value;
+                else Engine.Log.Error(LogCategory.Engine, "Cannot set value during transition.");
+            }
+        }
+        private float _OpeningDuration;
 
         /// <summary>
         /// トランジションを行うコルーチン

--- a/Engine/Node/Transition/TransitionNode.cs
+++ b/Engine/Node/Transition/TransitionNode.cs
@@ -24,12 +24,12 @@ namespace Altseed2
         /// <summary>
         /// トランジションが始まってからノードが入れ替わるまでの期間
         /// </summary>
-        public float ClosingDuration { get; set; } // ←アクセスレベルどうする問題
+        public float ClosingDuration { get; set; }
 
         /// <summary>
         /// ノードが入れ替わってからトランジションが終わるまでの期間
         /// </summary>
-        public float OpeningDuration { get; set; } // ←アクセスレベルどうする問題
+        public float OpeningDuration { get; set; }
 
         /// <summary>
         /// トランジションを行うコルーチン
@@ -55,7 +55,6 @@ namespace Altseed2
             if (!_OnTransition)
             {
                 _Coroutine = GetCoroutine();
-                _OnTransition = true;
 
                 OldNode = oldNode;
                 NewNode = newNode;
@@ -66,7 +65,7 @@ namespace Altseed2
         internal override void Update()
         {
             base.Update();
-            _OnTransition = _Coroutine.MoveNext();
+            _OnTransition = _Coroutine?.MoveNext() ?? false;
         }
 
         internal virtual void TransitionBegin()
@@ -168,6 +167,7 @@ namespace Altseed2
             }
 
             // トランジションの終了
+            Parent.RemoveChildNode(this);
             TransitionEnd();
         }
     }

--- a/Engine/Node/Transition/TransitionNode.cs
+++ b/Engine/Node/Transition/TransitionNode.cs
@@ -9,15 +9,27 @@ namespace Altseed2
     [Serializable]
     public class TransitionNode : Node
     {
-        /// <summary>
-        /// トランジションによって取り除かれるノード
-        /// </summary>
-        protected readonly Node _OldNode;
+        private bool _OnTransition;
 
         /// <summary>
-        /// トランジションによって追加されるノード
+        /// トランジションによって取り除かれるノード(トランジション中でない場合のみ設定可能)
         /// </summary>
-        protected readonly Node _NewNode;
+        public Node OldNode
+        {
+            get { return _OldNode; }
+            set { if (!_OnTransition) _OldNode = value; }
+        }
+        protected Node _OldNode;
+
+        /// <summary>
+        /// トランジションによって追加されるノード(トランジション中でない場合のみ設定可能)
+        /// </summary>
+        public Node NewNode
+        {
+            get { return _NewNode; }
+            set { if (!_OnTransition) _NewNode = value; }
+        }
+        protected Node _NewNode;
 
         /// <summary>
         /// トランジションを行うコルーチン
@@ -33,6 +45,8 @@ namespace Altseed2
         /// <param name="openingDuration">ノードが入れ替わってからトランジションが終わるまでの期間</param>
         public TransitionNode(Node oldNode, Node newNode, float closingDuration, float openingDuration)
         {
+            _OnTransition = false;
+
             _OldNode = oldNode;
             _NewNode = newNode;
 
@@ -112,6 +126,8 @@ namespace Altseed2
         /// </summary>
         private IEnumerator<int> GetCoroutine(float closingDuration, float openingDuration)
         {
+            _OnTransition = true;
+
             // トランジションの開始
             TransitionBegin();
             yield return 0;
@@ -146,6 +162,8 @@ namespace Altseed2
             // トランジションの終了
             Parent.RemoveChildNode(this);
             TransitionEnd();
+
+            _OnTransition = false;
         }
     }
 }

--- a/Engine/Node/Transition/TransitionNode.cs
+++ b/Engine/Node/Transition/TransitionNode.cs
@@ -14,12 +14,12 @@ namespace Altseed2
         /// <summary>
         /// トランジションによって取り除かれるノード
         /// </summary>
-        public Node OldNode { get; private set; }
+        public Node PrevNode { get; private set; }
 
         /// <summary>
         /// トランジションによって追加されるノード
         /// </summary>
-        public Node NewNode { get; private set; }
+        public Node NextNode { get; private set; }
 
         /// <summary>
         /// トランジションが始まってからノードが入れ替わるまでの期間
@@ -61,21 +61,21 @@ namespace Altseed2
         {
             _OnTransition = false;
 
-            OldNode = null;
-            NewNode = null;
+            PrevNode = null;
+            NextNode = null;
         }
 
         /// <summary>
         /// トランジションを開始します。
         /// </summary>
-        public void StartTransition(Node oldNode, Node newNode)
+        public void StartTransition(Node prevNode, Node nextNode)
         {
             if (!_OnTransition)
             {
                 _Coroutine = GetCoroutine();
 
-                OldNode = oldNode;
-                NewNode = newNode;
+                PrevNode = prevNode;
+                NextNode = nextNode;
             }
             else Engine.Log.Error(LogCategory.Engine, "Cannot start during transition.");
         }
@@ -169,9 +169,9 @@ namespace Altseed2
             yield return 0;
 
             // ノードの入れ替え
-            var parentNode = OldNode.Parent;
-            parentNode.RemoveChildNode(OldNode);
-            parentNode.AddChildNode(NewNode);
+            var parentNode = PrevNode.Parent;
+            parentNode.RemoveChildNode(PrevNode);
+            parentNode.AddChildNode(NextNode);
 
             // ノードが入れ替わった直後の処理
             NodeSwapped();

--- a/Samples/Transition/Transition.cs
+++ b/Samples/Transition/Transition.cs
@@ -30,11 +30,13 @@ namespace Sample
             amusementCreators.Position = new Vector2F(320, 240);
 
             // トランジションを行うノードを作成します。
-            var transitionNode = new MyTransitionNode(altseedPink, amusementCreators);
+            var transitionNode = new MyTransitionNode();
 
             // トランジションを行うノードを登録します。
-            // この瞬間、トランジションが開始されます。
             Engine.AddNode(transitionNode);
+
+            // トランジションを開始します。
+            transitionNode.StartTransition(altseedPink, amusementCreators);
 
             // メインループ。
             // Altseed のウインドウが閉じられると終了します。
@@ -56,8 +58,14 @@ namespace Sample
         private TransitionEffectNode _MyPostEffect;
 
         // コンストラクタ
-        public MyTransitionNode(Node oldNode, Node newNode) : base(oldNode, newNode, 1.0f, 1.0f)
+        public MyTransitionNode()
         {
+            // トランジションが始まってからノードが入れ替わるまでの期間を設定します。
+            ClosingDuration = 1.0f;
+
+            // ノードが入れ替わってからトランジションが終わるまでの期間を設定します。
+            OpeningDuration = 1.0f;
+
             // ポストエフェクトのノードを作成します。
             _MyPostEffect = new TransitionEffectNode();
 


### PR DESCRIPTION
## Changes/変更内容
<!-- PRの概要を記述してください。 -->
現行のTransitionNodeは、トランジションを行う際にインスタンスを生成することが前提になっている。TransitionNodeのインスタンスを使いまわしたいときに、インスタンス生成時にしかトランジション対象になるノードを設定できないのは不便。
→OldNode、NewNodeをpublicにして、トランジション中でない場合に対象のノードを付け替えられるように変更

<!-- Graphics関連の場合はスクリーンショットなどを貼るとレビューが楽です。 -->


## Issue
<!-- 対応するissueのURLを貼ってください。 -->
