### PR TITLE
Add check of initialization of graphics

### DIFF
--- a/Engine/Engine.cs
+++ b/Engine/Engine.cs
@@ -55,10 +55,14 @@ namespace Altseed2
             {
                 if (_ClearColor == value) return;
                 _ClearColor = value;
-                if (_DefaultCamera != null)
+
+                if (_DefaultCamera is null)
                 {
-                    _DefaultCamera.RenderPassParameter = new RenderPassParameter(value, true, true);
+                    Log.Warn(LogCategory.Engine, "Graphics機能が初期化されていません。");
+                    return;
                 }
+
+                _DefaultCamera.RenderPassParameter = new RenderPassParameter(value, true, true);
             }
         }
         private static Color _ClearColor = new Color(50, 50, 50, 255);

--- a/Engine/Engine.cs
+++ b/Engine/Engine.cs
@@ -55,7 +55,10 @@ namespace Altseed2
             {
                 if (_ClearColor == value) return;
                 _ClearColor = value;
-                _DefaultCamera.RenderPassParameter = new RenderPassParameter(value, true, true);
+                if (_DefaultCamera != null)
+                {
+                    _DefaultCamera.RenderPassParameter = new RenderPassParameter(value, true, true);
+                }
             }
         }
         private static Color _ClearColor = new Color(50, 50, 50, 255);
@@ -130,7 +133,7 @@ namespace Altseed2
             {
                 //ツール機能を使用するときはDoEventsでフレームを開始
                 //使用しないときはUpdateでフレームを開始
-                if (!Graphics.BeginFrame(new RenderPassParameter(ClearColor, true, true))) return false;
+                if (!_graphics.BeginFrame(new RenderPassParameter(ClearColor, true, true))) return false;
                 _tool.NewFrame();
             }
 
@@ -142,8 +145,13 @@ namespace Altseed2
         /// </summary>
         public static bool Update()
         {
-            var anyCamera = _CameraNodes.Count != 0;
-            return UpdateComponents(!anyCamera, anyCamera);
+            if (_CameraNodes != null)
+            {
+                var anyCamera = _CameraNodes.Count != 0;
+                return UpdateComponents(!anyCamera, anyCamera);
+            }
+
+            return true;
         }
 
         internal static bool UpdateComponents(bool drawDefaultCameraGroup, bool drawCustomCameraGroup)

--- a/Test/Engine.cs
+++ b/Test/Engine.cs
@@ -188,5 +188,16 @@ float4 main(PS_INPUT input) : SV_TARGET
                 Collection.Remove(this);
             }
         }
+
+        [Test, Apartment(ApartmentState.STA)]
+        public void CoreModulesNone()
+        {
+            var config = new Configuration { EnabledCoreModules = CoreModules.None };
+
+            var tc = new TestCore(config);
+            tc.Init();
+            tc.Init();
+            tc.End();
+        }
     }
 }


### PR DESCRIPTION
## Changes/変更内容
<!-- PRの概要を記述してください。 -->
CoreModulesでGraphicsが初期化されていない場合にnull checkを追加。
また、同様にnull checkが行われていない箇所に追加。

line 136は、_graphicsはnullではないはずなので直接参照して無駄を減らした。

<!-- Graphics関連の場合はスクリーンショットなどを貼るとレビューが楽です。 -->


## Issue
<!-- 対応するissueのURLを貼ってください。 -->
https://github.com/altseed/Altseed2/issues/663