### PR TITLE
specify cmake 3.18.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,9 +148,15 @@ jobs:
       with:
         path: Core/build
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('Core/core/**') }}
+    - name: Setup CMake
+      if: steps.cache-core.outputs.cache-hit != 'true'
+      uses: jwlawson/actions-setup-cmake@v1.4
+      with:
+        cmake-version: '3.18.x'
     - name: Build CMake
       if: steps.cache-core.outputs.cache-hit != 'true'
       run: |
+        cmake --version
         cd Core
         mkdir build
         cd build


### PR DESCRIPTION
## Changes/変更内容
<!-- PRの概要を記述してください。 -->
GitHub Actionsのmacosのversionをlatestから10.15に指定する。

```
CMake Error in CMakeLists.txt:
  The custom command generating
    /Users/runner/work/Altseed2-csharp/Altseed2-csharp/Core/build/thirdparty/Build/libpng/src/EP_libpng-build/pnglibconf.c
  is attached to multiple targets:
    genfiles
    gensym
    genvers
  but none of these is a common dependency of the other(s).  This is not
  allowed by the Xcode "new build system".
```

でこけていた。

最近リリースされたCmake 3.19でXcode の new build systemに対応と書いてある
https://cmake.org/cmake/help/latest/release/3.19.html

ので、バージョンを固定してみる。
以下を利用する。
https://github.com/jwlawson/actions-setup-cmake

<!-- Graphics関連の場合はスクリーンショットなどを貼るとレビューが楽です。 -->


## Issue
<!-- 対応するissueのURLを貼ってください。 -->
