### PR TITLE
Vector2F, Vector3F, Vector4F の Length プロパティ内の計算を修正

### DIFF
--- a/Engine/Math/Vector2F.cs
+++ b/Engine/Math/Vector2F.cs
@@ -51,6 +51,11 @@ namespace Altseed2
             readonly get => MathF.Sqrt(SquaredLength);
             set
             {
+                if (X == 0 && Y == 0)
+                {
+                    X = 1;
+                }
+                
                 var len = Length;
                 X *= (value / len);
                 Y *= (value / len);

--- a/Engine/Math/Vector2F.cs
+++ b/Engine/Math/Vector2F.cs
@@ -52,8 +52,8 @@ namespace Altseed2
             set
             {
                 var len = Length;
-                X /= (value / len);
-                Y /= (value / len);
+                X *= (value / len);
+                Y *= (value / len);
             }
         }
 

--- a/Engine/Math/Vector3F.cs
+++ b/Engine/Math/Vector3F.cs
@@ -37,9 +37,9 @@ namespace Altseed2
             set
             {
                 var len = Length;
-                X /= (value / len);
-                Y /= (value / len);
-                Z /= (value / len);
+                X *= (value / len);
+                Y *= (value / len);
+                Z *= (value / len);
             }
         }
 

--- a/Engine/Math/Vector3F.cs
+++ b/Engine/Math/Vector3F.cs
@@ -36,6 +36,11 @@ namespace Altseed2
             readonly get => MathF.Sqrt(SquaredLength);
             set
             {
+                if (X == 0 && Y == 0)
+                {
+                    X = 1;
+                }
+                
                 var len = Length;
                 X *= (value / len);
                 Y *= (value / len);

--- a/Engine/Math/Vector4F.cs
+++ b/Engine/Math/Vector4F.cs
@@ -42,6 +42,11 @@ namespace Altseed2
             readonly get => MathF.Sqrt(SquaredLength);
             set
             {
+                if (X == 0 && Y == 0)
+                {
+                    X = 1;
+                }
+                
                 var len = Length;
                 X *= (value / len);
                 Y *= (value / len);

--- a/Engine/Math/Vector4F.cs
+++ b/Engine/Math/Vector4F.cs
@@ -43,10 +43,10 @@ namespace Altseed2
             set
             {
                 var len = Length;
-                X /= (value / len);
-                Y /= (value / len);
-                Z /= (value / len);
-                W /= (value / len);
+                X *= (value / len);
+                Y *= (value / len);
+                Z *= (value / len);
+                W *= (value / len);
             }
         }
 

--- a/Test/Math.cs
+++ b/Test/Math.cs
@@ -59,7 +59,7 @@ namespace Altseed2.Test
         {
             var sourceVector = new Vector2F(sourceX, sourceY);
             sourceVector.Length = newLength;
-            Assert.AreEqual(newLength, sourceVector.Length);
+            TestValue(newLength, sourceVector.Length);
         }
         
         [Test]
@@ -70,7 +70,7 @@ namespace Altseed2.Test
         {
             var sourceVector = new Vector3F(sourceX, sourceY, sourceZ);
             sourceVector.Length = newLength;
-            Assert.AreEqual(newLength, sourceVector.Length);
+            TestValue(newLength, sourceVector.Length);
         }
         
         [Test]
@@ -81,7 +81,7 @@ namespace Altseed2.Test
         {
             var sourceVector = new Vector4F(sourceX, sourceY, sourceZ, sourceW);
             sourceVector.Length = newLength;
-            Assert.AreEqual(newLength, sourceVector.Length);
+            TestValue(newLength, sourceVector.Length);
         }
         
         public static void TestValue(float left, float right)
@@ -97,7 +97,7 @@ namespace Altseed2.Test
         {
             if (MathF.Abs(left.X - right.X) >= MathHelper.MatrixError) throw new AssertionException($"At X:\nleft: {left.X}\nright: {right.X}");
             if (MathF.Abs(left.Y - right.Y) >= MathHelper.MatrixError) throw new AssertionException($"At Y:\nleft: {left.Y}\nright: {right.Y}");
-            if (MathF.Abs(left.Z - right.Z) >= MathHelper.MatrixError) throw new AssertionException($"At Y:\nleft: {left.Z}\nright: {right.Z}");
+            if (MathF.Abs(left.Z - right.Z) >= MathHelper.MatrixError) throw new AssertionException($"At Z:\nleft: {left.Z}\nright: {right.Z}");
         }
         public static void TestValue(Matrix33F left, Matrix33F right)
         {

--- a/Test/Math.cs
+++ b/Test/Math.cs
@@ -51,6 +51,39 @@ namespace Altseed2.Test
             }
         }
 
+        [Test]
+        [TestCase(5f, 5f, 10f)]
+        [TestCase(5f, 5f, 0f)]
+        [TestCase(0f, 0f, float.NaN)]
+        public void Length2D(float sourceX, float sourceY, float newLength)
+        {
+            var sourceVector = new Vector2F(sourceX, sourceY);
+            sourceVector.Length = newLength;
+            Assert.AreEqual(newLength, sourceVector.Length);
+        }
+        
+        [Test]
+        [TestCase(5f, 5f, 2f, 10f)]
+        [TestCase(5f, 5f, 2f, 0f)]
+        [TestCase(0f, 0f, 0f, float.NaN)]
+        public void Length3D(float sourceX, float sourceY, float sourceZ, float newLength)
+        {
+            var sourceVector = new Vector3F(sourceX, sourceY, sourceZ);
+            sourceVector.Length = newLength;
+            Assert.AreEqual(newLength, sourceVector.Length);
+        }
+        
+        [Test]
+        [TestCase(5f, 5f, 2f, 2f, 10f)]
+        [TestCase(5f, 5f, 2f, 2f, 0f)]
+        [TestCase(0f, 0f, 0f, 0f, float.NaN)]
+        public void Length4D(float sourceX, float sourceY, float sourceZ, float sourceW, float newLength)
+        {
+            var sourceVector = new Vector4F(sourceX, sourceY, sourceZ, sourceW);
+            sourceVector.Length = newLength;
+            Assert.AreEqual(newLength, sourceVector.Length);
+        }
+        
         public static void TestValue(float left, float right)
         {
             if (MathF.Abs(left - right) >= MathHelper.MatrixError) throw new AssertionException($"left: {left}\nright: {right}");

--- a/Test/Math.cs
+++ b/Test/Math.cs
@@ -51,7 +51,7 @@ namespace Altseed2.Test
             }
         }
 
-        [Test]
+        [Test, Apartment(ApartmentState.STA)]
         [TestCase(5f, 5f, 10f)]
         [TestCase(5f, 5f, 0f)]
         [TestCase(0f, 0f, float.NaN)]
@@ -62,7 +62,7 @@ namespace Altseed2.Test
             TestValue(newLength, sourceVector.Length);
         }
         
-        [Test]
+        [Test, Apartment(ApartmentState.STA)]
         [TestCase(5f, 5f, 2f, 10f)]
         [TestCase(5f, 5f, 2f, 0f)]
         [TestCase(0f, 0f, 0f, float.NaN)]
@@ -73,7 +73,7 @@ namespace Altseed2.Test
             TestValue(newLength, sourceVector.Length);
         }
         
-        [Test]
+        [Test, Apartment(ApartmentState.STA)]
         [TestCase(5f, 5f, 2f, 2f, 10f)]
         [TestCase(5f, 5f, 2f, 2f, 0f)]
         [TestCase(0f, 0f, 0f, 0f, float.NaN)]

--- a/Test/Math.cs
+++ b/Test/Math.cs
@@ -51,10 +51,10 @@ namespace Altseed2.Test
             }
         }
 
-        [Test, Apartment(ApartmentState.STA)]
+        [Test]
         [TestCase(5f, 5f, 10f)]
         [TestCase(5f, 5f, 0f)]
-        [TestCase(0f, 0f, float.NaN)]
+        [TestCase(0f, 0f, 12f)]
         public void Length2D(float sourceX, float sourceY, float newLength)
         {
             var sourceVector = new Vector2F(sourceX, sourceY);
@@ -62,10 +62,10 @@ namespace Altseed2.Test
             TestValue(newLength, sourceVector.Length);
         }
         
-        [Test, Apartment(ApartmentState.STA)]
+        [Test]
         [TestCase(5f, 5f, 2f, 10f)]
         [TestCase(5f, 5f, 2f, 0f)]
-        [TestCase(0f, 0f, 0f, float.NaN)]
+        [TestCase(0f, 0f, 0f, 12f)]
         public void Length3D(float sourceX, float sourceY, float sourceZ, float newLength)
         {
             var sourceVector = new Vector3F(sourceX, sourceY, sourceZ);
@@ -73,10 +73,10 @@ namespace Altseed2.Test
             TestValue(newLength, sourceVector.Length);
         }
         
-        [Test, Apartment(ApartmentState.STA)]
+        [Test]
         [TestCase(5f, 5f, 2f, 2f, 10f)]
         [TestCase(5f, 5f, 2f, 2f, 0f)]
-        [TestCase(0f, 0f, 0f, 0f, float.NaN)]
+        [TestCase(0f, 0f, 0f, 0f, 12f)]
         public void Length4D(float sourceX, float sourceY, float sourceZ, float sourceW, float newLength)
         {
             var sourceVector = new Vector4F(sourceX, sourceY, sourceZ, sourceW);
@@ -86,6 +86,11 @@ namespace Altseed2.Test
         
         public static void TestValue(float left, float right)
         {
+            if (float.IsNaN(left) || float.IsNaN(right))
+            {
+                throw new AssertionException($"left: {left}\nright: {right}");
+            }
+            
             if (MathF.Abs(left - right) >= MathHelper.MatrixError) throw new AssertionException($"left: {left}\nright: {right}");
         }
         public static void TestValue(Vector2F left, Vector2F right)


### PR DESCRIPTION
## Changes/変更内容
<!-- PRの概要を記述してください。 -->
Vector2F, Vector3F, Vector4F の持つ Length プロパティの実装において、乗算であるべきところが除算になっていたため修正しました。また、Lengthプロパティに対するテストを追加しました。

<!-- Graphics関連の場合はスクリーンショットなどを貼るとレビューが楽です。 -->


## Issue
<!-- 対応するissueのURLを貼ってください。 -->
https://github.com/altseed/Altseed2/issues/667