### PR TITLE
fix GetIsCollidedWith(RectangleCollider c)

### DIFF
--- a/Engine/CorePartial/Collider.cs
+++ b/Engine/CorePartial/Collider.cs
@@ -61,7 +61,15 @@ namespace Altseed2
         /// </summary>
         /// <param name="collider">衝突判定を行うコライダ</param>
         /// <returns>このインスタンスと<paramref name="collider"/>が衝突していたらtrue，それ以外でfalse</returns>
-        public virtual bool GetIsCollidedWith(Collider collider) => cbg_Collider_GetIsCollidedWith(selfPtr, collider?.selfPtr ?? IntPtr.Zero);
+        public virtual bool GetIsCollidedWith(Collider collider)
+        {
+            if (collider is RectangleCollider r)
+            {
+                r.UpdateVertexes();
+            }
+
+            return cbg_Collider_GetIsCollidedWith(selfPtr, collider?.selfPtr ?? IntPtr.Zero);
+        }
     }
 
     public partial class CircleCollider
@@ -250,7 +258,7 @@ namespace Altseed2
 
             if (_buffersInternalCache is null) _buffersInternalCache = Int32Array.Create(buffers);
             else _buffersInternalCache.FromSpan(buffers);
-            
+
             BuffersInternal = _buffersInternalCache;
         }
 

--- a/Engine/Physics/Collider/RectangleCollider.cs
+++ b/Engine/Physics/Collider/RectangleCollider.cs
@@ -53,7 +53,7 @@ namespace Altseed2
         {
             Vertexes = Vector2FArray.Create(4);
         }
-        
+
         /// <summary>
         /// シリアライズされたデータをもとに<see cref="RectangleCollider"/>のインスタンスを生成します。
         /// </summary>
@@ -79,22 +79,24 @@ namespace Altseed2
         /// <inheritdoc/>
         public override bool GetIsCollidedWith(Collider collider)
         {
-            if (requireUpdate)
-            {
-                UpdateVertexes();
-                requireUpdate = false;
-            }
+            UpdateVertexes();
             return base.GetIsCollidedWith(collider);
         }
 
-        private void UpdateVertexes()
+        internal void UpdateVertexes()
         {
-            Span<Vector2F> positions = stackalloc Vector2F[4];
-            positions[0] = -_centerPosition;
-            positions[1] = new Vector2F(_size.X, 0f) - _centerPosition;
-            positions[2] = _size - _centerPosition;
-            positions[3] = new Vector2F(0f, _size.Y) - _centerPosition;
+            if (!requireUpdate) return;
+
+            Span<Vector2F> positions = stackalloc Vector2F[4]{
+                -_centerPosition,
+                new Vector2F(_size.X, 0f) - _centerPosition,
+                _size - _centerPosition,
+                new Vector2F(0f, _size.Y) - _centerPosition,
+            };
+
             SetVertexes(positions);
+
+            requireUpdate = false;
         }
     }
 }


### PR DESCRIPTION
## Changes/変更内容
<!-- PRの概要を記述してください。 -->
wraikny
`RectangleCollider` の `GetIsCollidedWith(Collider)` を呼ぶときは `UpdateVertexes()` が呼び出されるけど、 `RectangleCollider` を引数にとって `GetIsCollidedWith(Collider)` を呼び出すと `UpdateVertexes()` が呼び出されません！

wraikny
`RectangleCollider` は `ShapeCollider` を基にC#側で実装になっていて、 `Vertex` をCoreのObjectにセットした上で `GetCollidedWith` を使って判定を取りますが、 `RectangleCollider` の頂点の反映は遅延されている実装になっていて、それによって
`c1: RectangleCollider` `c2: Collider` としたとき、
`c1.Size = size; c1.GetCollidedWith(c2)` では `RectangleCollider.GetCollidedWith` の実装によりこの瞬間に遅延されていた頂点情報が反映されるため正しく処理されますtが、
`c1.Size = size; c2.GetCollidedWith(c1)` ではそのような処理がされていないので頂点情報が反映されないまま計算を行ってしまう。

NumAniCloud  20:50
説明ありがとうございます。これは型スイッチを使うのが良いかなと思いました。それというのも、計算を遅延実行するという責務は、RectangleColliderクラスの存在意義から素直に想像されるものではないと思ったからです。
C++との通信を減らしたいからRectangleColliderクラスを使用するとか、そういった事情がなければ別のクラスを使うというわけではないので、この部分をコンパイル時の型チェックで保証できていなくてもライブラリの質としては大差ないかなあと思っています。当然開発側は少し注意を要しますが、このためだけに抽象化するのも読みにくくなるリスクがありますし、プロパティを合併するとAPIが減って勿体ない気がしてます。

<!-- Graphics関連の場合はスクリーンショットなどを貼るとレビューが楽です。 -->


## Issue
<!-- 対応するissueのURLを貼ってください。 -->
https://github.com/altseed/Altseed2/issues/666