### PR TITLE
Fix to propagate 'IsDrawnActually'

### DIFF
--- a/Engine/Node/IDrawn.cs
+++ b/Engine/Node/IDrawn.cs
@@ -52,15 +52,27 @@ namespace Altseed2
         /// <summary>
         /// 自身と子孫ノードの IsDrawnActually プロパティを更新します。
         /// </summary>
-        internal static void UpdateIsDrawnActuallyOfDescendants<T>(this T node)
-            where T : Node, ICullableDrawn
+        internal static void UpdateIsDrawnActuallyOfDescendants(this Node node)
         {
-            node.IsDrawnActually = node.IsDrawn && (node.GetAncestorSpecificNode<T>()?.IsDrawnActually ?? true);
-
-            foreach (var child in node.Children)
+            static void UpdateRecursive(Node n, bool ancestorsIsDawnActually)
             {
-                if (child is T d)
-                    d.UpdateIsDrawnActuallyOfDescendants();
+                var dn = (ICullableDrawn)n;
+
+                var isDrawnActually = dn.IsDrawn && ancestorsIsDawnActually;
+                dn.IsDrawnActually = isDrawnActually;
+                foreach (var child in n.Children)
+                {
+                    if (child is ICullableDrawn)
+                    {
+                        UpdateRecursive(child, isDrawnActually);
+                    }
+                }
+            }
+
+            if (node is ICullableDrawn)
+            {
+                var ancestorsIsDrawnActually = node.GetAncestorSpecificNode<ICullableDrawn>()?.IsDrawnActually ?? true;
+                UpdateRecursive(node, ancestorsIsDrawnActually);
             }
         }
     }

--- a/Test/DrawnNode.cs
+++ b/Test/DrawnNode.cs
@@ -576,7 +576,6 @@ float4 main(PS_INPUT input) : SV_TARGET
             tc.End();
         }
 
-
         [Test, Apartment(ApartmentState.STA)]
         public void IsDrawn()
         {
@@ -597,7 +596,8 @@ float4 main(PS_INPUT input) : SV_TARGET
             node2.CenterPosition = texture.Size / 2;
             node2.Position = new Vector2F(200, 200);
 
-            var node3 = new SpriteNode();
+            var node3 = new RectangleNode();
+            node3.RectangleSize = texture.Size;
             node3.Texture = texture;
             node3.CenterPosition = texture.Size / 2;
             node3.Position = new Vector2F(300, 300);
@@ -608,20 +608,19 @@ float4 main(PS_INPUT input) : SV_TARGET
                 {
                     node.AddChildNode(node2);
                 }
-
-                if (c == 4)
+                else if (c == 4)
                 {
                     node.IsDrawn = false;
                     Assert.IsFalse(node.IsDrawnActually);
                     Assert.IsFalse(node2.IsDrawnActually);
                 }
 
-                if (c == 6)
+                else if (c == 6)
                 {
                     node2.AddChildNode(node3);
                 }
 
-                if (c == 8)
+                else if (c == 8)
                 {
                     node.IsDrawn = true;
 
@@ -629,8 +628,7 @@ float4 main(PS_INPUT input) : SV_TARGET
                     Assert.IsTrue(node2.IsDrawnActually);
                     Assert.IsTrue(node3.IsDrawnActually);
                 }
-
-                if (c == 10)
+                else if (c == 10)
                 {
                     node2.IsDrawn = false;
 


### PR DESCRIPTION
## Changes/変更内容
<!-- PRの概要を記述してください。 -->
`IsDrawnActually` が `SpriteNode` なら `SpriteNode` のみの子孫関係、 `TextNode` なら `TextNode` のみの子孫関係、といったふうにだけ伝播されていたので、任意の "`Node` かつ `ICullableDrawn`" 全てに伝播する変更を加えた。

### 修正手順
1. まず`IsDrawn` のテストにて`node3`で`RectangleNode`を利用することで、このテストが失敗することを確認した。
2. 次に`DrawnExtension.UpdateIsDrawnActuallyOfDescendants`を修正（ジェネリックを利用せず、ノードを受け取って動的に`ICullableDrawn`かチェック）
3. これにより、失敗していたテストが成功することをローカルで確認できた。

<!-- Graphics関連の場合はスクリーンショットなどを貼るとレビューが楽です。 -->


## Issue
<!-- 対応するissueのURLを貼ってください。 -->
https://github.com/altseed/Altseed2/issues/680
